### PR TITLE
Update user-agent options

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,25 +28,25 @@ Usage:
   getparty [OPTIONS] url
 
 Application Options:
-  -p, --parts=n                               number of parts (default: 2)
-  -r, --max-retry=n                           max retry per each part, 0 for infinite (default: 10)
-  -t, --timeout=sec                           context timeout (default: 15)
-  -o, --output=filename                       user defined output
-  -c, --continue=state.json                   resume download from the last session
-  -a, --user-agent=[chrome|firefox|safari]    User-Agent header (default: chrome)
-  -b, --best-mirror                           pickup the fastest mirror
-  -q, --quiet                                 quiet mode, no progress bars
-  -f, --force                                 overwrite existing file silently
-  -u, --username=                             basic http auth username
-      --password=                             basic http auth password
-  -H, --header=key:value                      arbitrary http header
-      --no-check-cert                         don't validate the server's certificate
-      --certs-file=certs.crt                  root certificates to use when verifying server certificates
-      --debug                                 enable debug to stderr
-      --version                               show version
+  -p, --parts=n                                             number of parts (default: 2)
+  -r, --max-retry=n                                         max retry per each part, 0 for infinite (default: 10)
+  -t, --timeout=sec                                         context timeout (default: 15)
+  -o, --output=filename                                     user defined output
+  -c, --continue=state.json                                 resume download from the last session
+  -a, --user-agent=[chrome|firefox|safari|edge|getparty]    User-Agent header (default: chrome)
+  -b, --best-mirror                                         pickup the fastest mirror
+  -q, --quiet                                               quiet mode, no progress bars
+  -f, --force                                               overwrite existing file silently
+  -u, --username=                                           basic http auth username
+      --password=                                           basic http auth password
+  -H, --header=key:value                                    arbitrary http header
+      --no-check-cert                                       don't validate the server's certificate
+      --certs-file=certs.crt                                root certificates to use when verifying server certificates
+      --debug                                               enable debug to stderr
+      --version                                             show version
 
 Help Options:
-  -h, --help                                  Show this help message
+  -h, --help                                                show this help message
 ```
 
 #### Best mirror example:

--- a/cmd/getparty/main.go
+++ b/cmd/getparty/main.go
@@ -17,8 +17,7 @@ import (
 )
 
 var (
-	version = "dev"
-	commit  = "xxxxxxx"
+	commit = "xxxxxxx"
 )
 
 func main() {
@@ -31,7 +30,7 @@ func main() {
 	}
 	os.Exit(cmd.Exit(cmd.Run(
 		os.Args[1:],
-		fmt.Sprintf("%s (%.7s) (%s)", version, commit, runtime.Version()),
+		fmt.Sprintf("%s (%.7s) (%s)", getparty.Version, commit, runtime.Version()),
 	)))
 }
 

--- a/getparty.go
+++ b/getparty.go
@@ -47,6 +47,10 @@ func (e HttpError) Error() string {
 }
 
 const (
+	Version = "dev"
+)
+
+const (
 	ErrCanceledByUser = ExpectedError("Canceled by user")
 	ErrMaxRedirects   = ExpectedError("Max redirects reached")
 	ErrMaxRetry       = ExpectedError("Max retry reached")
@@ -68,9 +72,11 @@ const (
 var reContentDisposition = regexp.MustCompile(`filename[^;\n=]*=(['"](.*?)['"]|[^;\n]*)`)
 
 var userAgents = map[string]string{
-	"chrome":  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36",
-	"firefox": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.13; rv:59.0) Gecko/20100101 Firefox/59.0",
-	"safari":  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_4) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/11.1 Safari/605.1.15",
+	"chrome":   "Mozilla/5.0 (Macintosh; Intel Mac OS X 11_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.101 Safari/537.36",
+	"firefox":  "Mozilla/5.0 (Macintosh; Intel Mac OS X 11.4; rv:89.0) Gecko/20100101 Firefox/89.0",
+	"safari":   "Mozilla/5.0 (Macintosh; Intel Mac OS X 11_4) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1 Safari/605.1.15",
+	"edge":     "Mozilla/5.0 (Macintosh; Intel Mac OS X 11_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.101 Safari/537.36 Edg/91.0.864.37",
+	"getparty": fmt.Sprintf("%s/%s", cmdName, Version),
 }
 
 // Options struct, represents cmd line options
@@ -80,7 +86,7 @@ type Options struct {
 	Timeout            uint              `short:"t" long:"timeout" value-name:"sec" default:"15" description:"context timeout"`
 	OutFileName        string            `short:"o" long:"output" value-name:"filename" description:"user defined output"`
 	JSONFileName       string            `short:"c" long:"continue" value-name:"state.json" description:"resume download from the last session"`
-	UserAgent          string            `short:"a" long:"user-agent" choice:"chrome" choice:"firefox" choice:"safari" default:"chrome" description:"User-Agent header"`
+	UserAgent          string            `short:"a" long:"user-agent" choice:"chrome" choice:"firefox" choice:"safari" choice:"edge" choice:"getparty" default:"chrome" description:"User-Agent header"`
 	BestMirror         bool              `short:"b" long:"best-mirror" description:"pickup the fastest mirror"`
 	Quiet              bool              `short:"q" long:"quiet" description:"quiet mode, no progress bars"`
 	ForceOverwrite     bool              `short:"f" long:"force" description:"overwrite existing file silently"`


### PR DESCRIPTION

Related to issue: https://github.com/vbauerster/getparty/issues/13

This PR includes the following changes:

* Updated user-agent strings for chrome/firefox/safari (updated to latest versions)
* Added edge user-agent string
* Added a getparty/version user-agent string
* Moved version const from the cmd into the getparty package so that it can be referenced for both the getparty user-agent string and cmd version output
* Maintained chrome as the default user-agent for compatibility
* Updated readme with new user-agent choices

Testing:

* All user-agents were tested against a couple of http file download servers to make sure they were not rejected. No issues were experienced.
* Verified that the default user-agent is still chrome.
* Executed getparty cmd binary against a private http server where I could review http access logs and verify that the correct user-agent was used. Also verified that the new 1st party user-agent for getparty was presented to the server successfully:

```
2021-06-14 00:13:24 x.x.x.x GET /download.file - 80 - x.x.x.x getparty/dev - 200 0 0 3
2021-06-14 00:13:24 x.x.x.x GET /download.file - 80 - x.x.x.x getparty/dev - 206 0 0 4
```
