### PR TITLE
Use SystemCertPool as the base when appending custom certificates

### DIFF
--- a/getparty.go
+++ b/getparty.go
@@ -716,7 +716,10 @@ func readCaCerts(name string) (*x509.CertPool, error) {
 		if err != nil {
 			return nil, err
 		}
-		caCerts.pool = x509.NewCertPool()
+		caCerts.pool, err = x509.SystemCertPool()
+		if err != nil {
+			return nil, err
+		}
 		caCerts.ok = caCerts.pool.AppendCertsFromPEM(b)
 	}
 	return caCerts.pool, nil


### PR DESCRIPTION
We noticed recently that NewCertPool was being used (which creates a empty pool) and then additional certificates were being appended to the empty pool. This causes the final certificate pool used by GetParty to not have any of the system certificates present (only the additional certs would be present).

This wasn't the desired behavior when this change was added, as the idea is to supplement the system pool with additional certs that are needed to trust a HTTPS endpoint that would otherwise not be trusted by the system/OS. If we don't include the system pool certs, the ramification is that we may not have the certificates needed to talk to other infrastructure (e.g. a SSL proxy).

With this change, the NewCertPool is replaced by SystemCertPool so that our pool is initialized with the default/system pool of certs. We then append the additional certs provided by the caller, which gives us the superset of system certs + additional certs.
